### PR TITLE
fix missing toolbar exception

### DIFF
--- a/src/quill.imageUploader.js
+++ b/src/quill.imageUploader.js
@@ -14,7 +14,9 @@ class ImageUploader {
             );
 
         var toolbar = this.quill.getModule("toolbar");
-        toolbar.addHandler("image", this.selectLocalImage.bind(this));
+        if (toolbar) {
+            toolbar.addHandler("image", this.selectLocalImage.bind(this));
+        }
 
         this.handleDrop = this.handleDrop.bind(this);
         this.handlePaste = this.handlePaste.bind(this);


### PR DESCRIPTION
If you choose to render quill without a toolbar (this might be done if you're rendering quill in read-only mode) then `toolbar.addHandler` throws an exception. This handles that case by adding a guard around the function call.