### PR TITLE
Fix for error when cancel uploading before success

### DIFF
--- a/src/quill.imageUploader.js
+++ b/src/quill.imageUploader.js
@@ -144,6 +144,8 @@ class ImageUploader {
                 console.warn(error);
             }
         );
+
+        this.placeholderDelta = null;
     }
 
     fileChanged() {

--- a/src/quill.imageUploader.js
+++ b/src/quill.imageUploader.js
@@ -178,6 +178,10 @@ class ImageUploader {
 
     // The length of the insert delta from insertBase64Image can vary depending on what part of the line the insert occurs
     calculatePlaceholderInsertLength() {
+        if (this.placeholderDelta === null) {
+            return 0;
+        }
+
         return this.placeholderDelta.ops.reduce((accumulator, deltaOperation) => {
             if (deltaOperation.hasOwnProperty('insert'))
                 accumulator++;

--- a/src/quill.imageUploader.js
+++ b/src/quill.imageUploader.js
@@ -4,8 +4,8 @@ class ImageUploader {
     constructor(quill, options) {
         this.quill = quill;
         this.options = options;
-        this.range = null;             
-        this.placeholderDelta = null; 
+        this.range = null;
+        this.placeholderDelta = null;
 
         if (typeof this.options.upload !== "function")
             console.warn(
@@ -153,7 +153,7 @@ class ImageUploader {
 
     insertBase64Image(url) {
         const range = this.range;
-                
+
         this.placeholderDelta = this.quill.insertEmbed(
             range.index,
             LoadingImage.blotName,
@@ -163,10 +163,10 @@ class ImageUploader {
     }
 
     insertToEditor(url) {
-        const range = this.range;        
+        const range = this.range;
 
-        const lengthToDelete = this.calculatePlaceholderInsertLength();        
-        
+        const lengthToDelete = this.calculatePlaceholderInsertLength();
+
         // Delete the placeholder image
         this.quill.deleteText(range.index, lengthToDelete, "user");
         // Insert the server saved image
@@ -178,7 +178,7 @@ class ImageUploader {
 
     // The length of the insert delta from insertBase64Image can vary depending on what part of the line the insert occurs
     calculatePlaceholderInsertLength() {
-        return this.placeholderDelta.ops.reduce((accumulator, deltaOperation) => {            
+        return this.placeholderDelta.ops.reduce((accumulator, deltaOperation) => {
             if (deltaOperation.hasOwnProperty('insert'))
                 accumulator++;
 
@@ -186,7 +186,7 @@ class ImageUploader {
         }, 0);
     }
 
-    removeBase64Image() {        
+    removeBase64Image() {
         const range = this.range;
         const lengthToDelete = this.calculatePlaceholderInsertLength();
 


### PR DESCRIPTION
Since `this.placeholderDelta` is updated only when the image upload is successful, the following two problems were occurring.

1. If the process was aborted before a successful upload, `calculartePlaceholderInsertLength` would refer to null properties and generate an error. https://github.com/NoelOConnell/quill-image-uploader/commit/6ebbba718b8829c637d9ccb1740bd216c1fb370c
2. `this.placeholderDelta` was never reset, so `this.placeholderDelta` obtained during the last upload could be referenced at the next upload timing. https://github.com/NoelOConnell/quill-image-uploader/commit/365cc4757363b547acb79a07d985d736985adc12

These errors occur when the following functions are passed to the upload property.
```js
options: {
  upload: async (file) => {
    if (file.size > 10 * 1024 * 1024) {
      throw new Error('A file size exceeded!');
    }
    return uploadFunc(file);
  },
},
```