### PR TITLE
Handle adding customizable accept types

### DIFF
--- a/src/quill.imageUploader.js
+++ b/src/quill.imageUploader.js
@@ -29,9 +29,8 @@ class ImageUploader {
         this.range = this.quill.getSelection();
         this.fileHolder = document.createElement("input");
         this.fileHolder.setAttribute("type", "file");
-        this.fileHolder.setAttribute("accept", this.options.accept ?? "image/*");
+        this.fileHolder.setAttribute("accept", this.options.accept.startsWith("image") ? this.options.accept : "image/*");
         this.fileHolder.setAttribute("style", "visibility:hidden");
-
         this.fileHolder.onchange = this.fileChanged.bind(this);
 
         document.body.appendChild(this.fileHolder);

--- a/src/quill.imageUploader.js
+++ b/src/quill.imageUploader.js
@@ -29,7 +29,7 @@ class ImageUploader {
         this.range = this.quill.getSelection();
         this.fileHolder = document.createElement("input");
         this.fileHolder.setAttribute("type", "file");
-        this.fileHolder.setAttribute("accept", "image/*");
+        this.fileHolder.setAttribute("accept", this.options.accept ?? "image/*");
         this.fileHolder.setAttribute("style", "visibility:hidden");
 
         this.fileHolder.onchange = this.fileChanged.bind(this);


### PR DESCRIPTION
# Description

This PR handles adding customizable image `accept` types. There are many applications where specific image types must be excluded/limited. 

By including a parameter on `options` we can effectively pump in this corresponding data; however, this still has the need to be constricted to actual image types. Although this could be by passed by something along the lines of
```
accept: "image/* video/* ..."
```
There is a clear UI indication being that other specified types won't render correctly, and it is also important to note that this parameter is optional. So although this might take away from the optimal path of this library, it opens up customization for those who need it.
